### PR TITLE
Fix layout breaking on smaller resolutions

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -96,7 +96,7 @@ div.page div.panel {
     display: block;
     float: left;
     width: 45%;
-    height: 270px;
+    height: 320px;
     margin: 0 20px 20px 0;
     padding: 0 20px 20px 20px;
     background-color: rgba(64, 7, 5, 0.9);
@@ -150,7 +150,7 @@ div.page div.form-group {
     display: block;
     float: left;
     width: 30%;
-    height: 300px;
+    height: 320px;
     margin: 0 20px 20px 0;
     padding: 15px 20px 20px 20px;
     background-color: rgba(64, 7, 5, 0.9);

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -1,0 +1,88 @@
+/**
+ * Borrorwed template from Michael Vieth at the Gist here: https://gist.github.com/mavieth/e0c8fdcb72a30d85f57a
+ */
+
+@media all and (max-width: 1600px) { 
+    div.page div.panel, div.page div.form-group {
+        height: 400px;
+    }
+
+    #hosting div.panel {
+        height: 600px;
+    }
+
+    #connecting div.panel {
+        height: 680px;
+    }
+}
+
+@media all and (max-width: 1350px) { 
+    div.page div.panel, div.page div.form-group {
+        height: 450px;
+    }
+
+    #hosting div.panel {
+        height: 650px;
+    }
+
+    #connecting div.panel {
+        height: 700px;
+    }
+}
+
+@media all and (max-width: 1200px) { 
+    div.page div.panel, div.page div.form-group {
+        height: 550px;
+    }
+
+    #hosting div.panel {
+        height: 700px;
+    }
+
+    #connecting div.panel {
+        height: 780px;
+    }
+}
+
+@media all and (max-width: 1100px) { 
+    div.page div.panel, div.page div.form-group {
+        height: 650px;
+    }
+
+    #hosting div.panel {
+        height: 750px;
+    }
+
+    #connecting div.panel {
+        height: 950px;
+    }
+}
+
+@media all and (max-width: 960px) { 
+    div.page div.panel, div.page div.form-group {
+        height: 750px;
+    }
+
+    #hosting div.panel {
+        height: 800px;
+    }
+
+    #connecting div.panel {
+        height: 1080px;
+    }
+}
+
+@media all and (max-width: 855px) { 
+    div.page div.panel, div.page div.form-group {
+        height: 900px;
+    }
+
+    #hosting div.panel {
+        height: 900px;
+    }
+
+    #connecting div.panel {
+        height: 1300px;
+    }
+}
+

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
         <link href="vendor/css/bootstrap-5.3.0.min.css" rel="stylesheet">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
         <link href="css/main.css" rel="stylesheet">
+        <link href="css/responsive.css" rel="stylesheet">
         <style>
             @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
         </style>


### PR DESCRIPTION
Saw a screenshot in Discord a few days ago that showed the text escaping from the boxes on a smaller res, so this PR fixes text layout for most common (smaller) resolutions.