### PR TITLE
Changing Oops All options to a dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,17 +208,15 @@
                                 </select>
                                 <div id="csw_explanation"></div>
                             </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="oops_all_rockets" id="oops_all_rockets" /> <label class="checkbox-label" for="oops_all_rockets">Oops! All Rockets</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="oops_all_miniguns" id="oops_all_miniguns" /> <label class="checkbox-label" for="oops_all_miniguns">Oops! All Miniguns</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="oops_all_grenades" id="oops_all_grenades" /> <label class="checkbox-label" for="oops_all_grenades">Oops! All Grenades</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="oops_all_knives" id="oops_all_knives" /> <label class="checkbox-label" for="oops_all_knives">Oops! All Knives</label>
+                            <div title="Enabling this swaps all weapons, weapon ammo, and subweapons to the selected weapon (except progression weapons, of course)">
+                                <label for="oops_all">Replace All Weapons:</label>
+                                <select name="oops_all">
+                                    <option title="Weapons, ammo and subweapons will not be swapped completely for a single weapon" value="disabled">Disabled</option>
+                                    <option title="Weapons, ammo and subweapons will be swapped out for rockets with a single shot" value="rockets">Oops All Rockets!</option>
+                                    <option title="Weapons, ammo and subweapons will be swapped out for miniguns with reduced ammo" value="miniguns">Oops All Miniguns!</option>
+                                    <option title="Weapons, ammo and subweapons will be swapped out for hand grenades" value="grenades">Oops All Grenades!</option>
+                                    <option title="Weapons, ammo and subweapons will be swapped out for knives" value="knives">Oops All Knives!</option>
+                                </select>
                             </div>
                         </div>
                         

--- a/js/main.js
+++ b/js/main.js
@@ -126,12 +126,14 @@ function exportYAML() {
         `${tab}allow_progression_in_labs: ${form_data['allow_progression_in_labs'] == 'on' ? true : false}\n` +
         `${tab}starting_ink_ribbons: ${form_data['starting_ink_ribbons']}\n`;
 
-    fileContents += `${tab}cross_scenario_weapons: ${form_data['cross_scenario_weapons']}\n` +
-        `${tab}oops_all_rockets: ${form_data['oops_all_rockets'] == 'on' ? true : false}\n` +
-        `${tab}oops_all_miniguns: ${form_data['oops_all_miniguns'] == 'on' ? true : false}\n` +
-        `${tab}oops_all_grenades: ${form_data['oops_all_grenades'] == 'on' ? true : false}\n` +
-        `${tab}oops_all_knives: ${form_data['oops_all_knives'] == 'on' ? true : false}\n` +
-        `${tab}ammo_pack_modifier: ${form_data['ammo_pack_modifier']}\n`;
+    fileContents += `${tab}cross_scenario_weapons: ${form_data['cross_scenario_weapons']}\n`;
+
+    fileContents += `${tab}oops_all_rockets: ${form_data['oops_all'] == 'rockets' }\n` +
+        `${tab}oops_all_miniguns: ${form_data['oops_all'] == 'miniguns' }\n` +
+        `${tab}oops_all_grenades: ${form_data['oops_all'] == 'grenades' }\n` +
+        `${tab}oops_all_knives: ${form_data['oops_all'] == 'knives' }\n`;
+
+    fileContents += `${tab}ammo_pack_modifier: ${form_data['ammo_pack_modifier']}\n`;
 
     fileContents += `${tab}no_first_aid_spray: ${form_data['no_first_aid_spray'] == 'on' ? true : false}\n` +
         `${tab}no_green_herb: ${form_data['no_green_herb'] == 'on' ? true : false}\n` +


### PR DESCRIPTION
This was originally in Johnny's PR here: https://github.com/FuzzyGamesOn/RE2R_AP_SetupGuide/pull/3

tbh, I dropped the ball on getting this approved earlier and then it fell into merge conflict hell. So I pulled out the dropdown as Johnny wrote it and made a couple of extremely minor tweaks. But works the same as they wrote it.

Oh, this PR replaces the Oops All checkboxes with a dropdown, which makes more sense because only one of them can be enabled at one time.