### PR TITLE
Balance options for a proper first-time experience

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -159,6 +159,25 @@ div.page div.form-group {
     font-size: 18px;
 }
 
+div.page div.form-group h4 em {
+    display: block;
+    font-size: 14px;
+    color: #777;
+    margin-bottom: 20px;
+}
+
+div.page div.form-group.notice {
+    background-color: rgba(64, 28, 5, 0.9);
+    border: 5px solid rgba(181, 83, 22);
+}
+
+div.page div.form-group.notice p.small {
+    font-size: 14px;
+    margin: 0 0 15px 0;
+    padding: 0px;
+    color: #777;
+}
+
 div.page div.form-group div.form-check {
     margin-left: -25px;
 }
@@ -246,12 +265,13 @@ button.next-step:hover {
 }
 
 #csw_explanation, #apm_explanation {
+    height: 80px;
     font-size: 14px;
     font-style: italic;
     color: #2296ba;
     border-bottom: 2px #bbb solid;
-    padding-bottom: 5px;
-    margin-bottom: 5px;
+    padding-bottom: 20px;
+    margin-bottom: 20px;
 }
 
 #apm_explanation {

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
                         <div class="form-group notice">
                             <strong>NOTE:</strong> 
                             <p>The options presented here are limited to options that are considered "safe" for community syncs and asyncs.</p>
-                            <p class="small"><em>Additionally, recommended checkbox options have been enabled.</em></p>
+                            <p class="small"><em>Additionally, recommended checkbox options are enabled by default on this screen.</em></p>
                             <p>For the full set of available options, you'll need to customize the template YAML provided with the apworld release.</p>
                         </div>
                         

--- a/index.html
+++ b/index.html
@@ -134,9 +134,6 @@
                                     <option value="hardcore">Hardcore</option>
                                 </select>
                             </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="death_link" id="death_link" /> <label class="checkbox-label" for="death_link">DeathLink</label>
-                            </div>
                         </div>
                         
                         <div class="form-group">
@@ -158,16 +155,13 @@
                                 <input type="checkbox" name="bonus_start" id="bonus_start" checked /> <label class="checkbox-label" for="bonus_start">Bonus Start</label> <span id="recommend_bonus_start">RECOMMENDED</span>
                             </div>
                             <div class="form-check">
-                                <input type="checkbox" name="extra_clock_tower_items" id="extra_clock_tower_items" /> <label class="checkbox-label" for="extra_clock_tower_items">Extra Clock Tower Items</label>
+                                <input type="checkbox" name="extra_clock_tower_items" id="extra_clock_tower_items" checked /> <label class="checkbox-label" for="extra_clock_tower_items">Extra Clock Tower Items</label>
                             </div>
                             <div class="form-check">
-                                <input type="checkbox" name="extra_medallions" id="extra_medallions" /> <label class="checkbox-label" for="extra_medallions">Extra Medallions</label>
+                                <input type="checkbox" name="extra_medallions" id="extra_medallions" checked /> <label class="checkbox-label" for="extra_medallions">Extra Medallions</label>
                             </div>
                             <div class="form-check">
-                                <input type="checkbox" name="early_medallions" id="early_medallions" /> <label class="checkbox-label" for="early_medallions">Early Medallions</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="allow_progression_in_labs" id="allow_progression_in_labs" /> <label class="checkbox-label" for="allow_progression_in_labs">Allow Progression in Labs</label>
+                                <input type="checkbox" name="early_medallions" id="early_medallions" checked /> <label class="checkbox-label" for="early_medallions">Early Medallions</label>
                             </div>
                             <div>
                                 <label for="starting_ink_ribbons">Starting Ink Ribbons:</label>
@@ -192,7 +186,10 @@
                         </div>
 
                         <div class="form-group">
-                            <h4>Weapon Customization</h4>
+                            <h4>
+                                Weapon Customization
+                                <em>Only one of the below two options can be enabled for your playthrough.</em>
+                            </h4>
 
                             <div>
                                 <label for="cross_scenario_weapons">Cross Scenario Weapons:</label>
@@ -202,12 +199,10 @@
                                     <option value="match">Match Level</option>
                                     <option value="full">Full Random</option>
                                     <option value="all">All Weapons</option>
-                                    <option value="full_ammo">Full + Ammo</option>
-                                    <option value="all_ammo">All + Ammo</option>
-                                    <option value="troll">Troll</option>
                                 </select>
                                 <div id="csw_explanation"></div>
                             </div>
+
                             <div title="Enabling this swaps all weapons, weapon ammo, and subweapons to the selected weapon (except progression weapons, of course)">
                                 <label for="oops_all">Replace All Weapons:</label>
                                 <select name="oops_all">
@@ -229,73 +224,18 @@
                                     <option value="none">None</option>
                                     <option value="max">Max</option>
                                     <option value="double">Double</option>
-                                    <option value="half">Half</option>
-                                    <option value="only_three">Only Three</option>
-                                    <option value="only_two">Only Two</option>
-                                    <option value="only_one">Only One</option>
-                                    <option value="random_by_type">Random By Type</option>
-                                    <option value="random_always">Random Always</option>
                                 </select>
                                 <div id="apm_explanation"></div>
                             </div>
                         </div>
-                        <div class="form-group">
-                            <h4>Item Removal Challenges</h4>
 
-                            <div class="form-check">
-                                <input type="checkbox" name="no_first_aid_spray" id="no_first_aid_spray" /> <label class="checkbox-label" for="no_first_aid_spray">No First Aid Sprays</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="no_green_herb" id="no_green_herb" /> <label class="checkbox-label" for="no_green_herb">No Green Herbs</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="no_red_herb" id="no_red_herb" /> <label class="checkbox-label" for="no_red_herb">No Red Herbs</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" name="no_gunpowder" id="no_gunpowder" /> <label class="checkbox-label" for="no_gunpowder">No Gunpowder</label>
-                            </div>
+                        <div class="form-group notice">
+                            <strong>NOTE:</strong> 
+                            <p>The options presented here are limited to options that are considered "safe" for community syncs and asyncs.</p>
+                            <p class="small"><em>Additionally, recommended checkbox options have been enabled.</em></p>
+                            <p>For the full set of available options, you'll need to customize the template YAML provided with the apworld release.</p>
                         </div>
                         
-                        <div class="form-group">
-                            <h4>Trap Options</h4>
-
-                            <div class="form-check">
-                                <input type="checkbox" name="add_damage_traps" id="add_damage_traps" /> <label class="checkbox-label" for="add_damage_traps">Add Damage Traps</label>
-                            </div>
-                            <div class="form-subgroup">
-                                <div>
-                                    <label for="damage_trap_count">Damage Traps Total:</label>
-                                    <select name="damage_trap_count">
-                                        <option value="5">5</option>
-                                        <option value="10">10</option>
-                                        <option value="15">15</option>
-                                        <option value="20">20</option>
-                                        <option value="25">25</option>
-                                        <option value="30">30</option>
-                                    </select>
-                                </div>
-                                <div class="form-check">
-                                    <input type="checkbox" name="damage_traps_can_kill" id="damage_traps_can_kill" /> <label class="checkbox-label" for="damage_traps_can_kill">Damage Traps Can Kill</label>
-                                </div>
-                            </div>
-                            
-                            <div class="form-check">
-                                <input type="checkbox" name="add_poison_traps" id="add_poison_traps" /> <label class="checkbox-label" for="add_poison_traps">Add Poison Traps</label>
-                            </div>
-                            <div class="form-subgroup">
-                                <div>
-                                    <label for="poison_trap_count">Poison Traps Total:</label>
-                                    <select name="poison_trap_count">
-                                        <option value="5">5</option>
-                                        <option value="10">10</option>
-                                        <option value="15">15</option>
-                                        <option value="20">20</option>
-                                        <option value="25">25</option>
-                                        <option value="30">30</option>
-                                    </select>
-                                </div>
-                            </div>
-                        </div>
                         <div class="action-group">
                             <button class="btn btn-primary" onclick="exportYAML()">Generate YAML</button><br />
                             <button class="btn btn-success next-step" data-step="#generation">Next Step: Generate</button>

--- a/js/main.js
+++ b/js/main.js
@@ -108,22 +108,20 @@ function exportYAML() {
     let fileContents = `name: ${player_name}\n` +
         "game: Resident Evil 2 Remake\n" +
         "requires:\n" + 
-        `${tab}version: 0.5.0\n\n` +
+        `${tab}version: 0.6.4\n\n` +
         "Resident Evil 2 Remake:\n" +
         `${tab}progression_balancing: 50\n` +
         `${tab}accessibility: items\n`;
 
     fileContents += `${tab}character: ${form_data['character']}\n` +
         `${tab}scenario: ${form_data['scenario']}\n` +
-        `${tab}difficulty: ${form_data['difficulty']}\n` +
-        `${tab}death_link: ${form_data['death_link'] == 'on' ? true : false}\n`;
+        `${tab}difficulty: ${form_data['difficulty']}\n`;
 
     fileContents += `${tab}starting_hip_pouches: ${form_data['starting_hip_pouches']}\n` +
-        `${tab}bonus_start: ${form_data['bonus_start'] == 'on' ? true : false}\n` +
-        `${tab}extra_clock_tower_items: ${form_data['extra_clock_tower_items'] == 'on' ? true : false}\n` +
-        `${tab}extra_medallions: ${form_data['extra_medallions'] == 'on' ? true : false}\n` +
-        `${tab}early_medallions: ${form_data['early_medallions'] == 'on' ? true : false}\n` +
-        `${tab}allow_progression_in_labs: ${form_data['allow_progression_in_labs'] == 'on' ? true : false}\n` +
+        `${tab}bonus_start: ${form_data['bonus_start'] == 'on'}\n` +
+        `${tab}extra_clock_tower_items: ${form_data['extra_clock_tower_items'] == 'on'}\n` +
+        `${tab}extra_medallions: ${form_data['extra_medallions'] == 'on'}\n` +
+        `${tab}early_medallions: ${form_data['early_medallions'] == 'on'}\n` +
         `${tab}starting_ink_ribbons: ${form_data['starting_ink_ribbons']}\n`;
 
     fileContents += `${tab}cross_scenario_weapons: ${form_data['cross_scenario_weapons']}\n`;
@@ -134,18 +132,6 @@ function exportYAML() {
         `${tab}oops_all_knives: ${form_data['oops_all'] == 'knives' }\n`;
 
     fileContents += `${tab}ammo_pack_modifier: ${form_data['ammo_pack_modifier']}\n`;
-
-    fileContents += `${tab}no_first_aid_spray: ${form_data['no_first_aid_spray'] == 'on' ? true : false}\n` +
-        `${tab}no_green_herb: ${form_data['no_green_herb'] == 'on' ? true : false}\n` +
-        `${tab}no_red_herb: ${form_data['no_red_herb'] == 'on' ? true : false}\n` +
-        `${tab}no_gunpowder: ${form_data['no_gunpowder'] == 'on' ? true : false}\n`;
-
-    fileContents += `${tab}add_damage_traps: ${form_data['add_damage_traps'] == 'on' ? true : false}\n` +
-        `${tab}damage_trap_count: ${form_data['damage_trap_count']}\n` +
-        `${tab}damage_traps_can_kill: ${form_data['damage_traps_can_kill'] == 'on' ? true : false}\n`;
-
-    fileContents += `${tab}add_poison_traps: ${form_data['add_poison_traps'] == 'on' ? true : false}\n` +
-        `${tab}poison_trap_count: ${form_data['poison_trap_count']}\n`;
 
     const file = new Blob([fileContents], { type: 'text/yaml' });
     saveAs(file, `RE2R_${player_name}.yaml`);


### PR DESCRIPTION
The goal of the Setup Guide is to get new players playing with a reasonable set of options. Up to now, the Setup Guide has tried to provide *every* option, and people often combine these to some detriment with some of the crazier options.

This PR reduces the options that can be chosen in the Setup Guide to only the ones that would make for a reasonable first time experience. For every other use case, players can use the generated template in the apworld release, or can generate their own templates, to access the more saucy options.

This PR also enables Extra Clock Tower, Extra Medallions, and Early Medallions by default, in addition to Bonus Start, which was previously also enabled to start.